### PR TITLE
refactor(dockerfile): newer and smaller

### DIFF
--- a/rootfs/curator/Dockerfile
+++ b/rootfs/curator/Dockerfile
@@ -1,17 +1,13 @@
 # Docker Definition for ElasticSearch Curator
 
-FROM ubuntu:17.10
-LABEL MAINTAINER="Deirdre Storck <deirdre.storck@gmail.com>, Jim Conner <snafu.x@gmail.com>" \
-      DESCRIPTION="Docker definition file for elasticsearch curator to be used with Samsung SDS ElasticSearch Chart"
+FROM debian:stable-slim
+LABEL MAINTAINER="OSS Maintainers <oss-maintainer@samsung-cnct.io>" \
+  DESCRIPTION="Docker definition file for elasticsearch curator to be used with Samsung SDS ElasticSearch Chart"
 
-RUN buildDeps='python-pip' && \
-    apt-get -qq update && \
-    apt-get install -y -qq $buildDeps && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN pip install --quiet elasticsearch-curator==5.5.1 && \
-		apt-get remove --purge --auto-remove -y -qq $buildDeps binutils perl
+RUN apt-get -qq update && \
+  apt-get install -y -qq python-pip && \
+  pip install --quiet elasticsearch-curator==5.6.0 && \
+  apt-get remove --purge --auto-remove -y -qq python-pip binutils perl && \
+  rm -rf /var/lib/apt/lists/* /var/cache/* /var/log/* /root/cache
 
 ENTRYPOINT [ "/usr/local/bin/curator" ]
-
-


### PR DESCRIPTION
- use debain:stable-slim base image
- use new OSS Maintainer email address
- bump elasticsearch curator version
- flatten docker image

Before: ubuntu:17.10
- layers: 7
- size: 438MB
- waste: 144MB
- efficiency: 70%

After: debian:stable-slim
- layers: 2
- size: 124MB
- waste: 386kb
- efficiency: 99